### PR TITLE
人気曲のリストを押下するとYoutubeのMV動画ページに遷移できるように

### DIFF
--- a/src/@types/env.d.ts
+++ b/src/@types/env.d.ts
@@ -1,5 +1,7 @@
 declare namespace NodeJS {
 	interface ProcessEnv {
+		readonly YOUTUBE_API_KEY: string;
+		readonly YOUTUBE_API_BASE_URL: string;
 		readonly SPOTIFY_CLIENT_ID: string;
 		readonly SPOTIFY_CLIENT_SECRET: string;
 		readonly SPOTIFY_API_BASE_URL: string;

--- a/src/app/(static)/artists/[artist_id]/_components/TrackArea.tsx
+++ b/src/app/(static)/artists/[artist_id]/_components/TrackArea.tsx
@@ -1,0 +1,55 @@
+"use client";
+import style from "@/app/(static)/artists/[artist_id]/_components/track-area.module.scss";
+import { useArtist } from "@/app/(static)/artists/[artist_id]/hook";
+import { TrackList } from "@/app/_components/client/TrackTable/TrackList";
+import type { SpotifyArtistTopTracksResponse } from "@/app/_fetchers/types";
+
+type Props = {
+	topTracks: SpotifyArtistTopTracksResponse;
+};
+
+export const TrackArea = ({ topTracks }: Props) => {
+	const { handleClickTrack } = useArtist();
+
+	const tracks = topTracks.tracks.map((track, index) => ({
+		id: track.id,
+		index: index + 1,
+		image: track.album.images[0].url,
+		title: track.name,
+		album: track.album.name,
+		artist: track.artists[0].name,
+		duration: track.duration_ms,
+	}));
+
+	const chunkedTracks = Array.from(
+		{ length: Math.ceil(tracks.length / 3) },
+		(_, i) => tracks.slice(i * 3, i * 3 + 3),
+	);
+
+	return (
+		<div className={style.scrollWrapper}>
+			<div className={style.gridContainer}>
+				{chunkedTracks.map((group, columnIndex) => (
+					<TrackList
+						key={String(columnIndex)}
+						tracks={group.map((track) => ({
+							id: track.id,
+							index: track.index,
+							image: track.image,
+							title: track.title,
+							album: track.album,
+							artist: track.artist,
+							duration: track.duration,
+							onClick: () =>
+								handleClickTrack({
+									artistName: track.artist,
+									musicName: track.title,
+									albumName: track.album,
+								}),
+						}))}
+					/>
+				))}
+			</div>
+		</div>
+	);
+};

--- a/src/app/(static)/artists/[artist_id]/_components/TrackArea.tsx
+++ b/src/app/(static)/artists/[artist_id]/_components/TrackArea.tsx
@@ -3,6 +3,7 @@ import style from "@/app/(static)/artists/[artist_id]/_components/track-area.mod
 import { useArtist } from "@/app/(static)/artists/[artist_id]/hook";
 import { TrackList } from "@/app/_components/client/TrackTable/TrackList";
 import type { SpotifyArtistTopTracksResponse } from "@/app/_fetchers/types";
+import { formatMsToMinSec } from "@/utils/helpers/formatDate";
 
 type Props = {
 	topTracks: SpotifyArtistTopTracksResponse;
@@ -18,7 +19,7 @@ export const TrackArea = ({ topTracks }: Props) => {
 		title: track.name,
 		album: track.album.name,
 		artist: track.artists[0].name,
-		duration: track.duration_ms,
+		duration: formatMsToMinSec(track.duration_ms),
 	}));
 
 	const chunkedTracks = Array.from(

--- a/src/app/(static)/artists/[artist_id]/_components/track-area.module.scss
+++ b/src/app/(static)/artists/[artist_id]/_components/track-area.module.scss
@@ -1,0 +1,13 @@
+.scrollWrapper {
+	overflow: hidden;
+	overflow-x: auto;
+	padding-bottom: 8px;
+	scrollbar-width: none;
+	  -ms-overflow-style: none;
+  }
+  
+  .gridContainer {
+	display: flex;
+	gap: 24px;
+	min-width: max-content;
+  }

--- a/src/app/(static)/artists/[artist_id]/hook.ts
+++ b/src/app/(static)/artists/[artist_id]/hook.ts
@@ -1,0 +1,29 @@
+import { getTopMovieBySearch } from "@/app/_fetchers/youtube/getTopMovieBySearch";
+
+export const useArtist = () => {
+	/**
+	 * トラックをクリックした時にYoutubeの動画を開く
+	 * TODO:iframeで表示してページ遷移しても表示され続けるようにする
+	 * @param artistName
+	 * @param musicName
+	 * @param albumName
+	 * @returns {void}
+	 */
+	const handleClickTrack = async ({
+		artistName,
+		musicName,
+		albumName,
+	}: { artistName: string; musicName: string; albumName: string }) => {
+		const res = await getTopMovieBySearch(
+			`${artistName} ${musicName} ${albumName}`,
+		);
+
+		if (!res) return;
+
+		window.open(res);
+	};
+
+	return {
+		handleClickTrack,
+	};
+};

--- a/src/app/(static)/artists/[artist_id]/page.tsx
+++ b/src/app/(static)/artists/[artist_id]/page.tsx
@@ -1,11 +1,13 @@
 import { ArtistHeader } from "@/app/(static)/artists/[artist_id]/_components/ArtistHeader";
 import { Jacket } from "@/app/_components/client/Jacket/Jacket";
-import { TrackList } from "@/app/_components/client/TrackTable/TrackList";
 import { Section, SectionWrapper } from "@/app/_components/layouts/Section";
 import { Slider } from "@/app/_components/layouts/Slider";
+
 import { getAlbumsByArtist } from "@/app/_fetchers/getAlbumsByArtist";
 import { getArtist } from "@/app/_fetchers/getArtist";
 import { getTopTracksByArtist } from "@/app/_fetchers/getTopTraksByArtist";
+
+import { TrackArea } from "@/app/(static)/artists/[artist_id]/_components/TrackArea";
 
 type Props = {
 	params: Promise<{ artist_id: string }>;
@@ -31,16 +33,7 @@ export default async function Artist({ params }: Props) {
 
 			<Section>
 				<h2>人気曲</h2>
-				<TrackList
-					tracks={topTracks.tracks.map((track, index) => ({
-						id: track.id,
-						index: index + 1,
-						image: track.album.images[0].url,
-						title: track.name,
-						album: track.album.name,
-						duration: track.duration_ms,
-					}))}
-				/>
+				<TrackArea topTracks={topTracks} />
 			</Section>
 
 			<Section>

--- a/src/app/_components/client/TrackTable/TrackList.tsx
+++ b/src/app/_components/client/TrackTable/TrackList.tsx
@@ -12,6 +12,7 @@ type Track = {
 	title: string;
 	album: string;
 	duration: number;
+	onClick: () => void;
 };
 
 type Props = {
@@ -19,38 +20,34 @@ type Props = {
 };
 
 export const TrackList = ({ tracks }: Props) => {
-	const chunkedTracks = Array.from(
-		{ length: Math.ceil(tracks.length / 3) },
-		(_, i) => tracks.slice(i * 3, i * 3 + 3),
-	);
-
 	return (
-		<div className={styles.scrollWrapper}>
-			<div className={styles.gridContainer}>
-				{chunkedTracks.map((group, columnIndex) => (
-					<div className={styles.column} key={String(columnIndex)}>
-						<ul className={styles.list}>
-							{group.map((track) => (
-								<li key={track.id} className={styles.row}>
-									<span className={helper.textEllipsis}>{track.index}</span>
-									<span>
-										<Image
-											className={styles.image}
-											src={track.image}
-											alt="トラック画像"
-											width={40}
-											height={40}
-										/>
-									</span>
-									<span className={helper.textEllipsis}>{track.title}</span>
-									<span className={helper.textEllipsis}>{track.album}</span>
-									<span className={helper.textEllipsis}>{track.duration}</span>
-								</li>
-							))}
-						</ul>
-					</div>
-				))}
+		<>
+			<div className={styles.column}>
+				<ul className={styles.list}>
+					{tracks.map((track) => (
+						<li
+							key={track.id}
+							className={styles.row}
+							onClick={() => track.onClick()}
+							onKeyDown={() => track.onClick()}
+						>
+							<span className={helper.textEllipsis}>{track.index}</span>
+							<span>
+								<Image
+									className={styles.image}
+									src={track.image}
+									alt="トラック画像"
+									width={40}
+									height={40}
+								/>
+							</span>
+							<span className={helper.textEllipsis}>{track.title}</span>
+							<span className={helper.textEllipsis}>{track.album}</span>
+							<span className={helper.textEllipsis}>{track.duration}</span>
+						</li>
+					))}
+				</ul>
 			</div>
-		</div>
+		</>
 	);
 };

--- a/src/app/_components/client/TrackTable/TrackList.tsx
+++ b/src/app/_components/client/TrackTable/TrackList.tsx
@@ -11,7 +11,7 @@ type Track = {
 	image: string;
 	title: string;
 	album: string;
-	duration: number;
+	duration: string;
 	onClick: () => void;
 };
 

--- a/src/app/_components/client/TrackTable/track-list.module.scss
+++ b/src/app/_components/client/TrackTable/track-list.module.scss
@@ -1,17 +1,3 @@
-.scrollWrapper {
-  overflow: hidden;
-  overflow-x: auto;
-  padding-bottom: 8px;
-  scrollbar-width: none;
-    -ms-overflow-style: none;
-}
-
-.gridContainer {
-  display: flex;
-  gap: 24px;
-  min-width: max-content;
-}
-
 .column {
   background-color: var(--gray-3);
   border-radius: 8px;
@@ -29,7 +15,7 @@
 .row {
   display: grid;
   gap: 16px;
-  grid-template-columns: auto auto 1fr 1fr 1fr;
+  grid-template-columns: auto auto 1fr 1fr auto;
   font-size: var(--font-size-2);
   padding: 10px 12px;
   border-radius: 8px;

--- a/src/app/_fetchers/youtube/getTopMovieBySearch.ts
+++ b/src/app/_fetchers/youtube/getTopMovieBySearch.ts
@@ -1,0 +1,21 @@
+/**
+ * Youtubeの検索結果トップの動画URLを取得
+ * @param {string} query
+ * @returns {Promise<string|null>}
+ */
+export async function getTopMovieBySearch(
+	query: string,
+): Promise<string | null> {
+	const encodeQuery = encodeURIComponent(query);
+	// apiRouterから取得
+	const url = `/api/youtube/top-video?q=${encodeQuery}`;
+
+	const res = await fetch(url);
+	const data: {
+		url: string;
+	} = await res.json();
+
+	if (!data.url) return null;
+
+	return data.url;
+}

--- a/src/app/_fetchers/youtube/types.ts
+++ b/src/app/_fetchers/youtube/types.ts
@@ -1,0 +1,49 @@
+/**
+ * 検索結果レスポンスのJSON
+ */
+export type YouTubeSearchResponse = {
+	kind: "youtube#searchListResponse";
+	etag: string;
+	nextPageToken?: string;
+	regionCode: string;
+	pageInfo: {
+		totalResults: number;
+		resultsPerPage: number;
+	};
+	items: YouTubeSearchItem[];
+};
+
+/**
+ * 検索結果アイテム
+ */
+export type YouTubeSearchItem = {
+	kind: "youtube#searchResult";
+	etag: string;
+	id: {
+		kind: "youtube#video";
+		videoId: string;
+	};
+	snippet: {
+		publishedAt: string;
+		channelId: string;
+		title: string;
+		description: string;
+		thumbnails: {
+			default: Thumbnail;
+			medium: Thumbnail;
+			high: Thumbnail;
+		};
+		channelTitle: string;
+		liveBroadcastContent: string;
+		publishTime: string;
+	};
+};
+
+/**
+ * サムネイル情報
+ */
+type Thumbnail = {
+	url: string;
+	width: number;
+	height: number;
+};

--- a/src/app/api/youtube/top-video/route.ts
+++ b/src/app/api/youtube/top-video/route.ts
@@ -12,10 +12,7 @@ export async function GET(request: Request) {
 	const query = searchParams.get("q");
 
 	if (!query) {
-		return NextResponse.json(
-			{ error: "Missing search query" },
-			{ status: 400 },
-		);
+		return new Response(null, { status: 400 });
 	}
 
 	const searchUrl = `${BASE_URL}/search?part=snippet&q=${encodeURIComponent(query)}&key=${API_KEY}&type=video&maxResults=1`;

--- a/src/app/api/youtube/top-video/route.ts
+++ b/src/app/api/youtube/top-video/route.ts
@@ -12,7 +12,10 @@ export async function GET(request: Request) {
 	const query = searchParams.get("q");
 
 	if (!query) {
-		return new Response(null, { status: 400 });
+		return NextResponse.json(
+			{ error: "Missing search query" },
+			{ status: 400 },
+		);
 	}
 
 	const searchUrl = `${BASE_URL}/search?part=snippet&q=${encodeURIComponent(query)}&key=${API_KEY}&type=video&maxResults=1`;
@@ -20,7 +23,8 @@ export async function GET(request: Request) {
 	const searchRes = await fetch(searchUrl);
 	const searchData = await searchRes.json();
 
-	if (searchData.items.length === 0) return null;
+	if (searchData.items.length === 0)
+		return NextResponse.json({ error: "No video found" }, { status: 404 });
 
 	const videoId = searchData.items[0].id.videoId;
 	const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;

--- a/src/app/api/youtube/top-video/route.ts
+++ b/src/app/api/youtube/top-video/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+const API_KEY = process.env.YOUTUBE_API_KEY;
+const BASE_URL = process.env.YOUTUBE_API_BASE_URL;
+
+/**
+ * Youtubeの検索結果トップの動画URLを取得
+ * @query q {string} 検索クエリ
+ */
+export async function GET(request: Request) {
+	const { searchParams } = new URL(request.url);
+	const query = searchParams.get("q");
+
+	if (!query) {
+		return NextResponse.json(
+			{ error: "Missing search query" },
+			{ status: 400 },
+		);
+	}
+
+	const searchUrl = `${BASE_URL}/search?part=snippet&q=${encodeURIComponent(query)}&key=${API_KEY}&type=video&maxResults=1`;
+
+	const searchRes = await fetch(searchUrl);
+	const searchData = await searchRes.json();
+
+	if (searchData.items.length === 0) return null;
+
+	const videoId = searchData.items[0].id.videoId;
+	const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
+
+	return NextResponse.json({ url: videoUrl });
+}

--- a/src/utils/helpers/formatDate.ts
+++ b/src/utils/helpers/formatDate.ts
@@ -1,0 +1,11 @@
+/**
+ * msを分:秒に変換する
+ * @param ms ミリ秒
+ * @returns {string} 分:秒
+ */
+export function formatMsToMinSec(ms: number): string {
+	const msToSec = Math.floor(ms / 1000);
+	const min = Math.floor(msToSec / 60);
+	const sec = msToSec % 60;
+	return `${min}:${sec.toString().padStart(2, "0")}`;
+}


### PR DESCRIPTION
- Youtube動画情報検索用のAPIRoute作成
- 検索結果トップの動画URLを取得するAPIFetcher作成
- 人気曲Listの曲を選択するとMV動画ページに飛ぶようにした
- 人気曲エリアでクライアントサイドの処理をできるように修正