### PR TITLE
検索ワード変更。FooterPlayerが閉じられた時の処理を改良。

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,4 +20,8 @@
         "**/*.module.scss.d.ts": true,
         "**/*.module.scss.d.ts.map": true,
     },
+    "cSpell.words": [
+        "enablejsapi",
+        "UNSTARTED"
+    ],
 }

--- a/src/app/_components/client/FooterPlayer/useFooterPlayer.tsx
+++ b/src/app/_components/client/FooterPlayer/useFooterPlayer.tsx
@@ -80,7 +80,7 @@ export const useFooterPlayer = () => {
 						console.log("📺 状態:", event.data);
 
 						switch (event.data) {
-							case window.YT.PlayerState.BUFFERING: {
+							case window.YT.PlayerState.UNSTARTED: {
 								if (!currentTrackIdRef.current && currentIndex !== 0) return;
 
 								// 次の動画のストックがない場合（nextTack）
@@ -117,7 +117,7 @@ export const useFooterPlayer = () => {
 
 				// 次の動画のVideoIdをセット
 				const res = await getTopMovieBySearch(
-					`${nextTrack.artist} ${nextTrack.title} ${nextTrack.album}`,
+					`${nextTrack.artist} ${nextTrack.title}`,
 				);
 
 				if (!res) return;
@@ -137,7 +137,7 @@ export const useFooterPlayer = () => {
 
 				// 次の動画のVideoIdをセット
 				const res = await getTopMovieBySearch(
-					`${prevTrack.artist} ${prevTrack.title} ${prevTrack.album}`,
+					`${prevTrack.artist} ${prevTrack.title}`,
 				);
 
 				if (!res) return;
@@ -168,7 +168,7 @@ export const useFooterPlayer = () => {
 
 			// 現在再生中のVideoIdをセット
 			const res = await getTopMovieBySearch(
-				`${currentTrack.artist} ${currentTrack.title} ${currentTrack.album}`,
+				`${currentTrack.artist} ${currentTrack.title}`,
 			);
 			if (!res) return;
 			videoListRef.current.push(res.videoId);
@@ -177,7 +177,7 @@ export const useFooterPlayer = () => {
 				currentTrackIdRef.current = nextTrack.id;
 				// 次の動画のVideoIdをセット
 				const res = await getTopMovieBySearch(
-					`${nextTrack.artist} ${nextTrack.title} ${nextTrack.album}`,
+					`${nextTrack.artist} ${nextTrack.title}`,
 				);
 				if (!res) return;
 				videoListRef.current.push(res.videoId);
@@ -187,7 +187,7 @@ export const useFooterPlayer = () => {
 				beforeTrackIdRef.current = prevTrack.id;
 				// 前の動画のVideoIdをセット
 				const res = await getTopMovieBySearch(
-					`${prevTrack.artist} ${prevTrack.title} ${prevTrack.album}`,
+					`${prevTrack.artist} ${prevTrack.title}`,
 				);
 				if (!res) return;
 				videoListRef.current.unshift(res.videoId);

--- a/src/libs/stores/video.ts
+++ b/src/libs/stores/video.ts
@@ -20,7 +20,7 @@ export const isOpenFooterAtom = atom<boolean>(false);
  * トラックテーブルで選択されたトラックのID
  * @type {string}
  */
-export const trackIdAtom = atom<string>("");
+export const trackIdAtom = atom<string | null>(null);
 
 /**
  * 連続再生キュー情報

--- a/src/libs/stores/video.ts
+++ b/src/libs/stores/video.ts
@@ -24,11 +24,14 @@ export const trackIdAtom = atom<string | null>(null);
 
 /**
  * 連続再生キュー情報
- * @type {object[]}
- * @constant {object[]}
+ * @type {Track[]}
+ * @property {string} id - 曲のID
+ * @property {number} index - テーブル出力時の曲のインデックス
+ * @property {string} image - 曲の画像URL
+ * @property {string} title - 曲のタイトル
+ * @property {string} album - アルバム名
+ * @property {string} artist - アーティスト名
+ * @property {string} duration - 曲の再生時間
  * @description 連続再生キュー情報を管理する
- * @property {string} artistName アーティスト名
- * @property {string} musicName 曲名
- * @property {string} albumName アルバム名
  */
 export const trackQueueAtom = atom<Track[]>([]);


### PR DESCRIPTION
- YoutubeDataAPIに渡す検索ワードはアーティスト名と曲名のみに変更（アルバム名が曲名判定されるため）
- 動画読み込みタイミングをバッファリング時に変更
- FooterPlayerが閉じられたら各種パラメータを初期化するようにした。