### PR TITLE
新着アルバム・シングルページ作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "lucide-react": "^0.511.0",
         "next": "15.3.2",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "swr": "^2.3.3"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -7891,7 +7892,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13003,6 +13003,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -13407,6 +13420,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "swr": "^2.3.3"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/src/app/(static)/albums/[album_id]/page.tsx
+++ b/src/app/(static)/albums/[album_id]/page.tsx
@@ -58,20 +58,20 @@ export default async function Album({ params }: Props) {
 					<h2>アーティストのその他のアルバム</h2>
 					<Slider>
 						{artistAlbumsData.items.map((item) => (
-							<Jacket
-								key={item.id}
-								href={PATH.ALBUMS(item.id)}
-								priority
-								src={
-									item.images.length
-										? item.images[0].url
-										: "/images/no-image.png"
-								}
-								album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
-								width={200}
-								height={200}
-								alt="アルバム画像"
-							/>
+							<div style={{ width: "200px" }} key={item.id}>
+								<Jacket
+									href={PATH.ALBUMS(item.id)}
+									fill
+									priority
+									src={
+										item.images.length
+											? item.images[0].url
+											: "/images/no-image.png"
+									}
+									album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
+									alt="アルバム画像"
+								/>
+							</div>
 						))}
 					</Slider>
 				</Section>

--- a/src/app/(static)/artists/[artist_id]/page.tsx
+++ b/src/app/(static)/artists/[artist_id]/page.tsx
@@ -42,18 +42,20 @@ export default async function Artist({ params }: Props) {
 				<h2>アルバム</h2>
 				<Slider>
 					{albums.items.map((item) => (
-						<Jacket
-							key={item.id}
-							href={PATH.ALBUMS(item.id)}
-							priority
-							src={
-								item.images.length ? item.images[0].url : "/images/no-image.png"
-							}
-							album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
-							width={200}
-							height={200}
-							alt="アルバム画像"
-						/>
+						<div style={{ width: "200px" }} key={item.id}>
+							<Jacket
+								href={PATH.ALBUMS(item.id)}
+								fill
+								priority
+								src={
+									item.images.length
+										? item.images[0].url
+										: "/images/no-image.png"
+								}
+								album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
+								alt="アルバム画像"
+							/>
+						</div>
 					))}
 				</Slider>
 			</Section>

--- a/src/app/(static)/new/hook.tsx
+++ b/src/app/(static)/new/hook.tsx
@@ -13,10 +13,16 @@ export const useNewRelease = () => {
 		const res = await fetch(url);
 
 		const data = (await res.json()) as SpotifyAlbumsResponse;
-		if (!data || !data.albums || data.albums.items.length === 0) {
+		if (
+			res.status === 404 ||
+			!data ||
+			!data.albums ||
+			data.albums.items.length === 0
+		) {
 			setHasMore(false);
-			return [];
+			return;
 		}
+
 		return data.albums.items;
 	};
 

--- a/src/app/(static)/new/hook.tsx
+++ b/src/app/(static)/new/hook.tsx
@@ -45,6 +45,7 @@ export const useNewRelease = () => {
 
 	return {
 		data,
+		isValidating,
 		lastElementRef,
 	};
 };

--- a/src/app/(static)/new/hook.tsx
+++ b/src/app/(static)/new/hook.tsx
@@ -21,7 +21,7 @@ export const useNewRelease = () => {
 	};
 
 	const getKey = (page: number) => {
-		return `/api/spotify/new-release?offset=${page * 20}&limit=20`;
+		return `/api/spotify/new-release?offset=${page * 24}&limit=24`;
 	};
 
 	const { data, size, setSize, isValidating } = useSWRInfinite(getKey, fetcher);

--- a/src/app/(static)/new/hook.tsx
+++ b/src/app/(static)/new/hook.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import useSWRInfinite from "swr/infinite";
+
+import type { SpotifyAlbumsResponse } from "@/app/_fetchers/types";
+
+export const useNewRelease = () => {
+	const [hasMore, setHasMore] = useState(true);
+	const lastElementRef = useRef<HTMLDivElement>(null);
+
+	const fetcher = async (url: string) => {
+		const res = await fetch(url);
+
+		const data = (await res.json()) as SpotifyAlbumsResponse;
+		if (!data || !data.albums || data.albums.items.length === 0) {
+			setHasMore(false);
+			return [];
+		}
+		return data.albums.items;
+	};
+
+	const getKey = (page: number) => {
+		return `/api/spotify/new-release?offset=${page * 20}&limit=20`;
+	};
+
+	const { data, size, setSize, isValidating } = useSWRInfinite(getKey, fetcher);
+
+	useEffect(() => {
+		const observer = new IntersectionObserver(([entries]) => {
+			if (entries.isIntersecting && !isValidating && hasMore) {
+				setSize(size + 1);
+			}
+		});
+
+		if (lastElementRef.current) {
+			observer.observe(lastElementRef.current);
+		}
+		return () => {
+			if (lastElementRef.current) {
+				observer.unobserve(lastElementRef.current);
+			}
+		};
+	}, [isValidating, setSize, hasMore, size]);
+
+	return {
+		data,
+		lastElementRef,
+	};
+};

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -4,8 +4,8 @@ import React from "react";
 
 import { useNewRelease } from "@/app/(static)/new/hook";
 import { Jacket } from "@/app/_components/server/Jacket/Jacket";
-import { Section } from "@/app/_styles/components/blocks";
-import { GapWrapper, PageWrapper } from "@/app/_styles/components/wrappers";
+import { InfiniteGrid, Section } from "@/app/_styles/components/blocks";
+import { PageWrapper } from "@/app/_styles/components/wrappers";
 
 export default function New() {
 	const { data, lastElementRef } = useNewRelease();
@@ -15,13 +15,14 @@ export default function New() {
 			<Section>
 				<h1>新着アルバム・シングル</h1>
 
-				<GapWrapper gap={24}>
+				<InfiniteGrid>
 					{data?.map((items) => (
 						<React.Fragment key={`parent-${items[0].id}`}>
 							{items.map((item) => (
 								<Jacket
 									key={item.id}
 									href={`/albums/${item.id}`}
+									fill
 									priority
 									src={item.images[0].url}
 									album={{ name: item.name, href: `/albums/${item.id}` }}
@@ -29,14 +30,12 @@ export default function New() {
 										name: item.artists[0].name,
 										href: `/artists/${item.artists[0].id}`,
 									}}
-									width={200}
-									height={200}
 									alt="最新リリースアルバム画像"
 								/>
 							))}
 						</React.Fragment>
 					))}
-				</GapWrapper>
+				</InfiniteGrid>
 
 				<div ref={lastElementRef}>最後の要素</div>
 			</Section>

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -1,52 +1,14 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import useSWRInfinite from "swr/infinite";
+import React from "react";
 
+import { useNewRelease } from "@/app/(static)/new/hook";
 import { Jacket } from "@/app/_components/server/Jacket/Jacket";
 import { Section } from "@/app/_styles/components/blocks";
 import { GapWrapper, PageWrapper } from "@/app/_styles/components/wrappers";
 
-import type { SpotifyAlbumsResponse } from "@/app/_fetchers/types";
-
 export default function New() {
-	const [hasMore, setHasMore] = useState(true);
-	const lastElementRef = useRef<HTMLDivElement>(null);
-
-	const fetcher = async (url: string) => {
-		const res = await fetch(url);
-
-		const data = (await res.json()) as SpotifyAlbumsResponse;
-		console.log("data:", data);
-		if (!data || !data.albums || data.albums.items.length === 0) {
-			setHasMore(false);
-			return [];
-		}
-		return data.albums.items;
-	};
-
-	const getKey = (page: number) => {
-		return `/api/spotify/new-release?offset=${page * 10}&limit=20`;
-	};
-
-	const { data, size, setSize, isValidating } = useSWRInfinite(getKey, fetcher);
-
-	useEffect(() => {
-		const observer = new IntersectionObserver(([entries]) => {
-			if (entries.isIntersecting && !isValidating && hasMore) {
-				setSize(size + 1);
-			}
-		});
-
-		if (lastElementRef.current) {
-			observer.observe(lastElementRef.current);
-		}
-		return () => {
-			if (lastElementRef.current) {
-				observer.unobserve(lastElementRef.current);
-			}
-		};
-	}, [isValidating, setSize, hasMore, size]);
+	const { data, lastElementRef } = useNewRelease();
 
 	return (
 		<PageWrapper>
@@ -54,8 +16,8 @@ export default function New() {
 				<h1>新着アルバム・シングル</h1>
 
 				<GapWrapper gap={24}>
-					{data?.map((items, index) => (
-						<React.Fragment key={`parent-${items[0].id + index}`}>
+					{data?.map((items) => (
+						<React.Fragment key={`parent-${items[0].id}`}>
 							{items.map((item) => (
 								<Jacket
 									key={item.id}

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -18,22 +18,26 @@ export default function New() {
 
 				<InfiniteGrid>
 					{data?.map((items) => (
-						<React.Fragment key={`parent-${items[0].id}`}>
-							{items.map((item) => (
-								<Jacket
-									key={item.id}
-									href={`/albums/${item.id}`}
-									fill
-									priority
-									src={item.images[0].url}
-									album={{ name: item.name, href: `/albums/${item.id}` }}
-									artist={{
-										name: item.artists[0].name,
-										href: `/artists/${item.artists[0].id}`,
-									}}
-									alt="最新リリースアルバム画像"
-								/>
-							))}
+						<React.Fragment key={items && `data-${items[0].id}`}>
+							{items && (
+								<React.Fragment key={`parent-${items[0].id}`}>
+									{items?.map((item) => (
+										<Jacket
+											key={item.id}
+											href={`/albums/${item.id}`}
+											fill
+											priority
+											src={item.images[0].url}
+											album={{ name: item.name, href: `/albums/${item.id}` }}
+											artist={{
+												name: item.artists[0].name,
+												href: `/artists/${item.artists[0].id}`,
+											}}
+											alt="最新リリースアルバム画像"
+										/>
+									))}
+								</React.Fragment>
+							)}
 						</React.Fragment>
 					))}
 				</InfiniteGrid>

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import useSWRInfinite from "swr/infinite";
+
+import { Jacket } from "@/app/_components/server/Jacket/Jacket";
+import { Section } from "@/app/_styles/components/blocks";
+import { GapWrapper, PageWrapper } from "@/app/_styles/components/wrappers";
+
+import type { SpotifyAlbumsResponse } from "@/app/_fetchers/types";
+
+export default function New() {
+	const [hasMore, setHasMore] = useState(true);
+	const lastElementRef = useRef<HTMLDivElement>(null);
+
+	const fetcher = async (url: string) => {
+		const res = await fetch(url);
+
+		const data = (await res.json()) as SpotifyAlbumsResponse;
+		console.log("data:", data);
+		if (!data || !data.albums || data.albums.items.length === 0) {
+			setHasMore(false);
+			return [];
+		}
+		return data.albums.items;
+	};
+
+	const getKey = (page: number) => {
+		return `/api/spotify/new-release?offset=${page * 10}&limit=20`;
+	};
+
+	const { data, size, setSize, isValidating } = useSWRInfinite(getKey, fetcher);
+
+	useEffect(() => {
+		const observer = new IntersectionObserver(([entries]) => {
+			if (entries.isIntersecting && !isValidating && hasMore) {
+				setSize(size + 1);
+			}
+		});
+
+		if (lastElementRef.current) {
+			observer.observe(lastElementRef.current);
+		}
+		return () => {
+			if (lastElementRef.current) {
+				observer.unobserve(lastElementRef.current);
+			}
+		};
+	}, [isValidating, setSize, hasMore, size]);
+
+	return (
+		<PageWrapper>
+			<Section>
+				<h1>新着アルバム・シングル</h1>
+
+				<GapWrapper gap={24}>
+					{data?.map((items, index) => (
+						<React.Fragment key={`parent-${items[0].id + index}`}>
+							{items.map((item) => (
+								<Jacket
+									key={item.id}
+									href={`/albums/${item.id}`}
+									priority
+									src={item.images[0].url}
+									album={{ name: item.name, href: `/albums/${item.id}` }}
+									artist={{
+										name: item.artists[0].name,
+										href: `/artists/${item.artists[0].id}`,
+									}}
+									width={200}
+									height={200}
+									alt="最新リリースアルバム画像"
+								/>
+							))}
+						</React.Fragment>
+					))}
+				</GapWrapper>
+
+				<div ref={lastElementRef}>最後の要素</div>
+			</Section>
+		</PageWrapper>
+	);
+}

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -41,7 +41,14 @@ export default function New() {
 				{isValidating && (
 					<InfiniteGrid>
 						{[...Array(24).keys()].map((i) => (
-							<Skeleton key={i} loading style={{ aspectRatio: "1 / 1" }}>
+							<Skeleton
+								key={i}
+								loading
+								style={{
+									borderRadius: "var(--radius-4)",
+									aspectRatio: "1 / 1",
+								}}
+							>
 								<div>
 									<br />
 								</div>

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Skeleton } from "@radix-ui/themes";
 import React from "react";
 
 import { useNewRelease } from "@/app/(static)/new/hook";
@@ -8,7 +9,7 @@ import { InfiniteGrid, Section } from "@/app/_styles/components/blocks";
 import { PageWrapper } from "@/app/_styles/components/wrappers";
 
 export default function New() {
-	const { data, lastElementRef } = useNewRelease();
+	const { data, isValidating, lastElementRef } = useNewRelease();
 
 	return (
 		<PageWrapper>
@@ -37,7 +38,19 @@ export default function New() {
 					))}
 				</InfiniteGrid>
 
-				<div ref={lastElementRef}>最後の要素</div>
+				{isValidating && (
+					<InfiniteGrid>
+						{[...Array(24).keys()].map((i) => (
+							<Skeleton key={i} loading style={{ aspectRatio: "1 / 1" }}>
+								<div>
+									<br />
+								</div>
+							</Skeleton>
+						))}
+					</InfiniteGrid>
+				)}
+
+				<div ref={lastElementRef} />
 			</Section>
 		</PageWrapper>
 	);

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -18,26 +18,22 @@ export default function New() {
 
 				<InfiniteGrid>
 					{data?.map((items) => (
-						<React.Fragment key={items && `data-${items[0].id}`}>
-							{items && (
-								<React.Fragment key={`parent-${items[0].id}`}>
-									{items?.map((item) => (
-										<Jacket
-											key={item.id}
-											href={`/albums/${item.id}`}
-											fill
-											priority
-											src={item.images[0].url}
-											album={{ name: item.name, href: `/albums/${item.id}` }}
-											artist={{
-												name: item.artists[0].name,
-												href: `/artists/${item.artists[0].id}`,
-											}}
-											alt="最新リリースアルバム画像"
-										/>
-									))}
-								</React.Fragment>
-							)}
+						<React.Fragment key={items && `parent-${items[0].id}`}>
+							{items?.map((item) => (
+								<Jacket
+									key={item.id}
+									href={`/albums/${item.id}`}
+									fill
+									priority
+									src={item.images[0].url}
+									album={{ name: item.name, href: `/albums/${item.id}` }}
+									artist={{
+										name: item.artists[0].name,
+										href: `/artists/${item.artists[0].id}`,
+									}}
+									alt="最新リリースアルバム画像"
+								/>
+							))}
 						</React.Fragment>
 					))}
 				</InfiniteGrid>

--- a/src/app/(static)/new/page.tsx
+++ b/src/app/(static)/new/page.tsx
@@ -18,7 +18,7 @@ export default function New() {
 
 				<InfiniteGrid>
 					{data?.map((items) => (
-						<React.Fragment key={items && `parent-${items[0].id}`}>
+						<React.Fragment key={items ? `parent-${items[0].id}` : "no-items"}>
 							{items?.map((item) => (
 								<Jacket
 									key={item.id}

--- a/src/app/(static)/page.tsx
+++ b/src/app/(static)/page.tsx
@@ -20,20 +20,20 @@ export default async function Home() {
 				<h1>新着</h1>
 				<Slider>
 					{newReleaseData.albums.items.map((item) => (
-						<Jacket
-							href={PATH.ALBUMS(item.id)}
-							key={item.id}
-							priority
-							src={item.images[0].url}
-							album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
-							artist={{
-								name: item.artists[0].name,
-								href: PATH.ARTISTS(item.artists[0].id),
-							}}
-							width={200}
-							height={200}
-							alt="最新リリースアルバム画像"
-						/>
+						<div style={{ width: "200px" }} key={item.id}>
+							<Jacket
+								href={PATH.ALBUMS(item.id)}
+								fill
+								priority
+								src={item.images[0].url}
+								album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
+								artist={{
+									name: item.artists[0].name,
+									href: PATH.ARTISTS(item.artists[0].id),
+								}}
+								alt="最新リリースアルバム画像"
+							/>
+						</div>
 					))}
 				</Slider>
 			</Section>
@@ -42,20 +42,20 @@ export default async function Home() {
 				<h1>人気</h1>
 				<Slider>
 					{popularityData.albums.items.map((item) => (
-						<Jacket
-							key={item.id}
-							href={PATH.ALBUMS(item.id)}
-							priority
-							src={item.images[0].url}
-							album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
-							artist={{
-								name: item.artists[0].name,
-								href: PATH.ARTISTS(item.artists[0].id),
-							}}
-							width={200}
-							height={200}
-							alt="国内人気アルバム画像"
-						/>
+						<div style={{ width: "200px" }} key={item.id}>
+							<Jacket
+								href={PATH.ALBUMS(item.id)}
+								fill
+								priority
+								src={item.images[0].url}
+								album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
+								artist={{
+									name: item.artists[0].name,
+									href: PATH.ARTISTS(item.artists[0].id),
+								}}
+								alt="国内人気アルバム画像"
+							/>
+						</div>
 					))}
 				</Slider>
 			</Section>
@@ -64,16 +64,16 @@ export default async function Home() {
 				<h1>ジャンル</h1>
 				<Slider>
 					{genres.map((genre) => (
-						<Genre
-							key={genre.id}
-							href="/"
-							priority
-							src={genre.src}
-							genreName={genre.name}
-							width={200}
-							height={200}
-							alt="ジャンル画像"
-						/>
+						<div style={{ width: "200px" }} key={genre.id}>
+							<Genre
+								href="/"
+								fill
+								priority
+								src={genre.src}
+								genreName={genre.name}
+								alt="ジャンル画像"
+							/>
+						</div>
 					))}
 				</Slider>
 			</Section>

--- a/src/app/(static)/search/page.tsx
+++ b/src/app/(static)/search/page.tsx
@@ -65,21 +65,23 @@ export default async function Search({ searchParams }: Props) {
 							{artists?.length > 0 && (
 								<GapWrapper gap={8} direction="column">
 									<h3>アーティスト</h3>
-									<Artist
-										href={PATH.ARTISTS(artists[0].id)}
-										src={
-											artists[0].images.length
-												? artists[0].images[0].url
-												: "/images/no-image.png"
-										}
-										artist={{
-											name: artists[0].name,
-											href: PATH.ARTISTS(artists[0].id),
-										}}
-										width={200}
-										height={200}
-										alt="アーティスト画像"
-									/>
+									<div style={{ width: "200px" }}>
+										<Artist
+											href={PATH.ARTISTS(artists[0].id)}
+											fill
+											priority
+											src={
+												artists[0].images.length
+													? artists[0].images[0].url
+													: "/images/no-image.png"
+											}
+											artist={{
+												name: artists[0].name,
+												href: PATH.ARTISTS(artists[0].id),
+											}}
+											alt="アーティスト画像"
+										/>
+									</div>
 								</GapWrapper>
 							)}
 
@@ -120,22 +122,23 @@ export default async function Search({ searchParams }: Props) {
 							<h2>アーティスト</h2>
 							<Slider>
 								{artists.map((artist) => (
-									<Artist
-										key={artist.id}
-										href={PATH.ARTISTS(artist.id)}
-										src={
-											artist.images.length
-												? artist.images[0].url
-												: "/images/no-image.png"
-										}
-										artist={{
-											name: artist.name,
-											href: PATH.ARTISTS(artist.id),
-										}}
-										width={150}
-										height={150}
-										alt="アーティスト画像"
-									/>
+									<div style={{ width: "150px" }} key={artist.id}>
+										<Artist
+											href={PATH.ARTISTS(artist.id)}
+											fill
+											priority
+											src={
+												artist.images.length
+													? artist.images[0].url
+													: "/images/no-image.png"
+											}
+											artist={{
+												name: artist.name,
+												href: PATH.ARTISTS(artist.id),
+											}}
+											alt="アーティスト画像"
+										/>
+									</div>
 								))}
 							</Slider>
 						</Section>

--- a/src/app/(static)/search/page.tsx
+++ b/src/app/(static)/search/page.tsx
@@ -86,21 +86,23 @@ export default async function Search({ searchParams }: Props) {
 							{albums?.length > 0 && (
 								<GapWrapper gap={8} direction="column">
 									<h3>アルバム</h3>
-									<Jacket
-										href={PATH.ALBUMS(albums[0].id)}
-										src={
-											albums[0].images.length
-												? albums[0].images[0].url
-												: "/images/no-image.png"
-										}
-										album={{
-											name: albums[0].name,
-											href: PATH.ALBUMS(albums[0].id),
-										}}
-										width={200}
-										height={200}
-										alt="アルバム画像"
-									/>
+									<div style={{ width: "200px" }}>
+										<Jacket
+											href={PATH.ALBUMS(albums[0].id)}
+											fill
+											priority
+											src={
+												albums[0].images.length
+													? albums[0].images[0].url
+													: "/images/no-image.png"
+											}
+											album={{
+												name: albums[0].name,
+												href: PATH.ALBUMS(albums[0].id),
+											}}
+											alt="アルバム画像"
+										/>
+									</div>
 								</GapWrapper>
 							)}
 
@@ -144,19 +146,20 @@ export default async function Search({ searchParams }: Props) {
 							<h2>アルバム</h2>
 							<Slider>
 								{albums.map((album) => (
-									<Jacket
-										key={album.id}
-										href={PATH.ALBUMS(album.id)}
-										src={
-											album.images.length
-												? album.images[0].url
-												: "/images/no-image.png"
-										}
-										album={{ name: album.name, href: PATH.ALBUMS(album.id) }}
-										width={200}
-										height={200}
-										alt="アルバム画像"
-									/>
+									<div style={{ width: "200px" }} key={album.id}>
+										<Jacket
+											href={PATH.ALBUMS(album.id)}
+											fill
+											priority
+											src={
+												album.images.length
+													? album.images[0].url
+													: "/images/no-image.png"
+											}
+											album={{ name: album.name, href: PATH.ALBUMS(album.id) }}
+											alt="アルバム画像"
+										/>
+									</div>
 								))}
 							</Slider>
 						</Section>

--- a/src/app/_components/server/Artist/Artist.tsx
+++ b/src/app/_components/server/Artist/Artist.tsx
@@ -16,22 +16,14 @@ type ArtistProps = ImageProps & {
 
 export const Artist = ({ href, artist, ...props }: ArtistProps) => {
 	return (
-		<GapWrapper
-			gap={8}
-			direction="column"
-			style={{ width: `${props.width}px` }}
-		>
-			<Link
-				href={href}
-				style={{ width: `${props.width}px`, height: `${props.height}px` }}
-				className={style.artist}
-			>
-				<Image className={style.artistImg} {...props} alt="image" />
+		<GapWrapper gap={8} direction="column">
+			<Link href={href} className={style.artist}>
+				<Image className={style.artistImg} {...props} />
 			</Link>
 			<GapWrapper direction="column">
 				<LinkText
-					className={helper.textEllipsis}
 					href={artist?.href || PATH[404]}
+					className={helper.textEllipsis}
 				>
 					{artist?.name}
 				</LinkText>

--- a/src/app/_components/server/Artist/artist.module.scss
+++ b/src/app/_components/server/Artist/artist.module.scss
@@ -1,6 +1,9 @@
 .artist {
     position: relative;
     cursor: pointer;
+    width: 100%;
+    height: 0;
+    padding-bottom: 100%;
 }
 
 .artistImg {

--- a/src/app/_components/server/Genre/Genre.tsx
+++ b/src/app/_components/server/Genre/Genre.tsx
@@ -10,12 +10,8 @@ type GenreProps = ImageProps & {
 
 export const Genre = ({ href, genreName, ...props }: GenreProps) => {
 	return (
-		<Link
-			href={href}
-			style={{ width: `${props.width}px`, height: `${props.height}px` }}
-			className={style.genre}
-		>
-			<Image className={style.genreImg} {...props} alt="image" />
+		<Link href={href} className={style.genre}>
+			<Image className={style.genreImg} {...props} />
 			<div className={style.genreText}>{genreName}</div>
 		</Link>
 	);

--- a/src/app/_components/server/Genre/genre.module.scss
+++ b/src/app/_components/server/Genre/genre.module.scss
@@ -1,6 +1,9 @@
 .genre {
     position: relative;
     cursor: pointer;
+    width: 100%;
+    height: 0;
+    padding-bottom: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -29,6 +32,8 @@
 
 .genreText {
     position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
     font-size: 1.5rem;
     font-weight: bold;
     opacity: 0;

--- a/src/app/_components/server/Jacket/Jacket.tsx
+++ b/src/app/_components/server/Jacket/Jacket.tsx
@@ -17,17 +17,9 @@ type JacketProps = ImageProps & {
 
 export const Jacket = ({ href, album, artist, ...props }: JacketProps) => {
 	return (
-		<GapWrapper
-			gap={8}
-			direction="column"
-			style={{ width: `${props.width}px` }}
-		>
-			<Link
-				href={href}
-				style={{ width: `${props.width}px`, height: `${props.height}px` }}
-				className={style.jacket}
-			>
-				<Image className={style.jacketImg} {...props} alt="image" />
+		<GapWrapper gap={8} direction="column">
+			<Link href={href} className={style.jacket}>
+				<Image className={style.jacketImg} {...props} />
 			</Link>
 			<GapWrapper direction="column">
 				<LinkText

--- a/src/app/_components/server/Jacket/jacket.module.scss
+++ b/src/app/_components/server/Jacket/jacket.module.scss
@@ -1,6 +1,9 @@
 .jacket {
     position: relative;
     cursor: pointer;
+    width: 100%;
+    height: 0;
+    padding-bottom: 100%;
 }
 
 .jacketImg {

--- a/src/app/_fetchers/getNewReleases.ts
+++ b/src/app/_fetchers/getNewReleases.ts
@@ -5,9 +5,13 @@ import { fetchSpotifyData } from "@/libs/spotify";
  * Spotify の新着アルバムを取得
  * @returns {Promise<SpotifyAlbumsResponse>}
  */
-export async function getNewReleases() {
+export async function getNewReleases({
+	offset = 0,
+	limit = 20,
+}: { offset?: number; limit?: number } = {}) {
 	const res = await fetchSpotifyData<SpotifyAlbumsResponse>(
-		"browse/new-releases",
+		`browse/new-releases?offset=${offset}&limit=${limit}&market=JP&language=ja-JP`,
 	);
+
 	return res;
 }

--- a/src/app/_styles/components/blocks/index.module.scss
+++ b/src/app/_styles/components/blocks/index.module.scss
@@ -16,3 +16,9 @@
 .slider::-webkit-scrollbar {
     display: none; /* Chrome, Safariでスクロールバーを非表示 */
   }
+
+.infiniteGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 24px;
+}

--- a/src/app/_styles/components/blocks/index.module.scss
+++ b/src/app/_styles/components/blocks/index.module.scss
@@ -19,6 +19,6 @@
 
 .infiniteGrid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    grid-template-columns: repeat(6, 1fr);
     gap: 24px;
 }

--- a/src/app/_styles/components/blocks/index.tsx
+++ b/src/app/_styles/components/blocks/index.tsx
@@ -15,3 +15,11 @@ interface SliderProps {
 export const Slider = ({ children }: SliderProps) => {
 	return <div className={style.slider}>{children}</div>;
 };
+
+interface InfiniteGridProps {
+	children: React.ReactNode;
+}
+
+export const InfiniteGrid = ({ children }: InfiniteGridProps) => {
+	return <div className={style.infiniteGrid}>{children}</div>;
+};

--- a/src/app/api/spotify/new-release/route.ts
+++ b/src/app/api/spotify/new-release/route.ts
@@ -1,0 +1,31 @@
+import { getNewReleases } from "@/app/_fetchers/getNewReleases";
+import type { SpotifyAlbumsResponse } from "@/app/_fetchers/types";
+import { NextResponse } from "next/server";
+
+/**
+ * Spotifyの新着リリースを取得するAPIエンドポイント
+ */
+export async function GET(request: Request) {
+	const { searchParams } = new URL(request.url);
+	const offset = Number(searchParams.get("offset") || 0);
+	const limit = Number(searchParams.get("limit") || 20);
+
+	const res = await getNewReleases({
+		offset,
+		limit,
+	});
+	const data: SpotifyAlbumsResponse = await res;
+
+	try {
+		if (!data.albums || data.albums.items.length === 0) {
+			return NextResponse.json(
+				{ error: "No new releases found" },
+				{ status: 404 },
+			);
+		}
+
+		return NextResponse.json(data, { status: 200 });
+	} catch (error) {
+		return NextResponse.json({ error: error }, { status: 500 });
+	}
+}

--- a/src/app/api/spotify/new-release/route.ts
+++ b/src/app/api/spotify/new-release/route.ts
@@ -8,7 +8,7 @@ import { NextResponse } from "next/server";
 export async function GET(request: Request) {
 	const { searchParams } = new URL(request.url);
 	const offset = Number(searchParams.get("offset") || 0);
-	const limit = Number(searchParams.get("limit") || 20);
+	const limit = Number(searchParams.get("limit") || 24);
 
 	const res = await getNewReleases({
 		offset,

--- a/src/stories/server/Artist.stories.tsx
+++ b/src/stories/server/Artist.stories.tsx
@@ -58,15 +58,16 @@ const DUMMY_IMAGES = [
 
 export const Primary: Story = {
 	render: () => (
-		<Artist
-			href="/"
-			priority
-			src={"/images/no-image.png"}
-			artist={{ name: "artist", href: "/" }}
-			width={150}
-			height={150}
-			alt="dummy"
-		/>
+		<div style={{ width: "150px" }}>
+			<Artist
+				href="/"
+				fill
+				priority
+				src={"/images/no-image.png"}
+				artist={{ name: "artist", href: "/" }}
+				alt="dummy"
+			/>
+		</div>
 	),
 };
 
@@ -75,16 +76,16 @@ export const WithSlider: Story = {
 		<div style={{ width: "1000px" }}>
 			<Slider>
 				{DUMMY_IMAGES.map((image) => (
-					<Artist
-						key={image.id}
-						href="/"
-						priority
-						src={image.src}
-						artist={{ name: image.artistName, href: "/" }}
-						width={150}
-						height={150}
-						alt="dummy"
-					/>
+					<div style={{ width: "150px" }} key={image.id}>
+						<Artist
+							href="/"
+							fill
+							priority
+							src={image.src}
+							artist={{ name: image.artistName, href: "/" }}
+							alt="dummy"
+						/>
+					</div>
 				))}
 			</Slider>
 		</div>

--- a/src/stories/server/Genre.stories.tsx
+++ b/src/stories/server/Genre.stories.tsx
@@ -58,15 +58,16 @@ const DUMMY_GENRES = [
 
 export const Primary: Story = {
 	render: () => (
-		<Genre
-			href="/"
-			priority
-			src={"/images/no-image.png"}
-			genreName="genre"
-			width={200}
-			height={200}
-			alt="dummy"
-		/>
+		<div style={{ width: "200px" }}>
+			<Genre
+				href="/"
+				fill
+				priority
+				src={"/images/no-image.png"}
+				genreName="genre"
+				alt="dummy"
+			/>
+		</div>
 	),
 };
 
@@ -75,16 +76,16 @@ export const WithSlider: Story = {
 		<div style={{ width: "1000px" }}>
 			<Slider>
 				{DUMMY_GENRES.map((genre) => (
-					<Genre
-						key={genre.id}
-						href="/"
-						priority
-						src={genre.src}
-						genreName={genre.genreName}
-						width={200}
-						height={200}
-						alt="dummy"
-					/>
+					<div style={{ width: "200px" }} key={genre.id}>
+						<Genre
+							href="/"
+							fill
+							priority
+							src={genre.src}
+							genreName={genre.genreName}
+							alt="dummy"
+						/>
+					</div>
 				))}
 			</Slider>
 		</div>

--- a/src/stories/server/Jacket.stories.tsx
+++ b/src/stories/server/Jacket.stories.tsx
@@ -65,16 +65,17 @@ const DUMMY_IMAGES = [
 
 export const Primary: Story = {
 	render: () => (
-		<Jacket
-			href="/"
-			priority
-			src={"/images/no-image.png"}
-			album={{ name: "music", href: "/" }}
-			artist={{ name: "artist", href: "/" }}
-			width={200}
-			height={200}
-			alt="dummy"
-		/>
+		<div style={{ width: "200px" }}>
+			<Jacket
+				href="/"
+				fill
+				priority
+				src={"/images/no-image.png"}
+				album={{ name: "music", href: "/" }}
+				artist={{ name: "artist", href: "/" }}
+				alt="dummy"
+			/>
+		</div>
 	),
 };
 
@@ -83,17 +84,17 @@ export const WithSlider: Story = {
 		<div style={{ width: "1000px" }}>
 			<Slider>
 				{DUMMY_IMAGES.map((image) => (
-					<Jacket
-						key={image.id}
-						href="/"
-						priority
-						src={image.src}
-						album={{ name: image.albumName, href: "/" }}
-						artist={{ name: image.artistName, href: "/" }}
-						width={200}
-						height={200}
-						alt="dummy"
-					/>
+					<div style={{ width: "200px" }} key={image.id}>
+						<Jacket
+							href="/"
+							fill
+							priority
+							src={image.src}
+							album={{ name: image.albumName, href: "/" }}
+							artist={{ name: image.artistName, href: "/" }}
+							alt="dummy"
+						/>
+					</div>
 				))}
 			</Slider>
 		</div>


### PR DESCRIPTION
- 最新アルバム・シングルを全件取得するためのページ作成
- 最新アルバムをページネーションで取得できるように最新アルバム取得APIを修正
- 上記のAPIRoute作成
- swrインストール
- 無限スクロールでデータを取得できるように
- 無限スクロールで取得できるデータがない場合はスケルトンを表示できるように
- Jacket・Genre・Artistコンポーネントは親でサイズ指定して表示できるようにも変更


https://github.com/user-attachments/assets/cb5b2c8a-0082-4d35-b633-0783ee77281e

