### PR TITLE
無限レンダリングでのfetchで404レスポンスが帰ってきた時の参照落ち解消

### DIFF
--- a/src/app/(static)/new/hook.tsx
+++ b/src/app/(static)/new/hook.tsx
@@ -16,7 +16,7 @@ export const useNewRelease = () => {
 
 		if (res.status.code !== 200) {
 			setHasMore(false);
-			return [];
+			return;
 		}
 
 		return res.data?.albums.items;

--- a/src/app/(static)/page.tsx
+++ b/src/app/(static)/page.tsx
@@ -5,6 +5,7 @@ import { getNewReleases } from "@/app/_fetchers/getNewReleases";
 import { getPopularityAlbums } from "@/app/_fetchers/getPopularityAlbums";
 
 import { Section, Slider } from "@/app/_styles/components/blocks";
+import { LinkText } from "@/app/_styles/components/texts";
 import { PageWrapper } from "@/app/_styles/components/wrappers";
 
 import { genres } from "@/app/(static)/_utils/_constants";
@@ -21,6 +22,7 @@ export default async function Home() {
 		<PageWrapper>
 			<Section>
 				<h1>新着</h1>
+
 				<Slider>
 					{newReleaseData.albums.items.map((item) => (
 						<div style={{ width: "200px" }} key={item.id}>
@@ -39,10 +41,13 @@ export default async function Home() {
 						</div>
 					))}
 				</Slider>
+
+				<LinkText href={PATH.NEW}>▶︎ ReadMoreNewAlbums...</LinkText>
 			</Section>
 
 			<Section>
 				<h1>人気</h1>
+
 				<Slider>
 					{popularityData.albums.items.map((item) => (
 						<div style={{ width: "200px" }} key={item.id}>
@@ -61,6 +66,8 @@ export default async function Home() {
 						</div>
 					))}
 				</Slider>
+
+				<LinkText href={PATH.POPULARITY}>▶︎ ReadMorePopularAlbums...</LinkText>
 			</Section>
 
 			<Section>

--- a/src/app/(static)/popularity/hook.tsx
+++ b/src/app/(static)/popularity/hook.tsx
@@ -16,7 +16,7 @@ export default function usePopularity() {
 
 		if (res.status.code !== 200) {
 			setHasMore(false);
-			return [];
+			return;
 		}
 
 		return res.data?.albums.items;


### PR DESCRIPTION
- 無限レンダリングでのfetchで404レスポンスが帰ってきた時の参照落ち解消
- ついでにトップページにnewページとpopularityページへの導線を追加