### PR TITLE
人気曲リストのレイアウト修正

### DIFF
--- a/src/app/(static)/artists/[artist_id]/_components/TopTrackList.tsx
+++ b/src/app/(static)/artists/[artist_id]/_components/TopTrackList.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 
 import type { SpotifyArtistTopTracksResponse } from "@/app/_fetchers/types";
 
+import { BasicText } from "@/app/_styles/components/texts";
+
 import style from "@/app/(static)/artists/[artist_id]/_components/top-track-list.module.scss";
 
 import { formatMsToMinSec } from "@/utils/helpers/formatDate";
@@ -84,9 +86,20 @@ export const TopTrackList = ({ topTracks }: Props) => {
 											height={40}
 										/>
 									</span>
-									<span className="textEllipsis-2">{track.title}</span>
-									<span className="textEllipsis-2">{track.album}</span>
-									<span className="textEllipsis-1">{track.duration}</span>
+									<span>
+										<BasicText className="textEllipsis-1">
+											{track.title}
+										</BasicText>
+										<BasicText
+											className="textEllipsis-1"
+											style={{ color: "var(--gray-10)" }}
+										>
+											{track.album}
+										</BasicText>
+									</span>
+									<span className="textEllipsis-1 display-none-sp">
+										{track.duration}
+									</span>
 								</li>
 							))}
 						</ul>

--- a/src/app/(static)/artists/[artist_id]/_components/top-track-list.module.scss
+++ b/src/app/(static)/artists/[artist_id]/_components/top-track-list.module.scss
@@ -21,11 +21,11 @@
 	flex-shrink: 0;
 
 	@include mq(sm) {
-		width: 340px;
+		width: 280px;
 	}
 
 	@include mq(md) {
-		width: 600px;
+		width: 500px;
 	}
   }
   
@@ -38,7 +38,7 @@
   .row {
 	display: grid;
 	gap: 16px;
-	grid-template-columns: 24px auto 1fr 1fr auto;
+	grid-template-columns: 24px auto 1fr auto;
 	font-size: var(--font-size-2);
 	padding: 10px 12px;
 	border-radius: var(--radius-4);


### PR DESCRIPTION
スマホで見た際に人気曲リストがスライド可能な事がわかりにくいので小幅でも表示しやすいレイアウトに修正した。

SP画面：

<img width="385" height="277" alt="スクリーンショット 2025-08-02 22 09 44" src="https://github.com/user-attachments/assets/568f3f6c-aa73-451f-bcd4-f9695f17b841" />

PC画面：
<img width="1224" height="313" alt="スクリーンショット 2025-08-02 22 09 53" src="https://github.com/user-attachments/assets/c42ca46a-f003-425c-af36-e2c9b4ef61fc" />

