### PR TITLE
ビルドするとSkeletonのborder-radiusが効いていない不具合を解消

### DIFF
--- a/src/app/(static)/artists/[artist_id]/_components/ArtistHeader/Loading.tsx
+++ b/src/app/(static)/artists/[artist_id]/_components/ArtistHeader/Loading.tsx
@@ -6,8 +6,8 @@ import style from "./loading.module.scss";
 export const Loading = () => {
 	return (
 		<GapWrapper direction="column" gap={24}>
-			<Skeleton className={style.skeletonImage} />
-			<Skeleton className={style.skeletonText} />
+			<Skeleton className={`${style.skeletonImage} radius-full`} />
+			<Skeleton className={`${style.skeletonText} radius-3`} />
 		</GapWrapper>
 	);
 };

--- a/src/app/(static)/artists/[artist_id]/_components/ArtistHeader/loading.module.scss
+++ b/src/app/(static)/artists/[artist_id]/_components/ArtistHeader/loading.module.scss
@@ -2,7 +2,6 @@
 
 .skeletonImage {
 	margin:auto;
-	border-radius: 50%;
 
 	@include mq(sm) {
 		width: 240px;
@@ -17,7 +16,6 @@
 
 .skeletonText {
 	width: 240px;
-	border-radius: var(--radius-4);
 
 	@include mq(sm) {
 		height: 26px;

--- a/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/Loading.tsx
+++ b/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/Loading.tsx
@@ -7,7 +7,7 @@ export const Loading = () => {
 		<div className={style.skeletonWrapper}>
 			<div className={style.skeletonContainer}>
 				{[...Array(3).keys()].map((i) => (
-					<Skeleton key={i} className={style.skeletonColumn} />
+					<Skeleton key={i} className={`${style.skeletonColumn} radius-1`} />
 				))}
 			</div>
 		</div>

--- a/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/loading.module.scss
+++ b/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/loading.module.scss
@@ -16,7 +16,6 @@
 
   .skeletonColumn {
 	background-color: var(--gray-3);
-	border-radius: var(--radius-4);
 	padding: 8px;
 	flex-shrink: 0;
 	height: 200px;

--- a/src/app/_components/server/Jacket/Artist/Loading.tsx
+++ b/src/app/_components/server/Jacket/Artist/Loading.tsx
@@ -8,10 +8,12 @@ export const Loading = () => {
 		<>
 			{[...Array(12).keys()].map((i) => (
 				<GapWrapper key={i} direction="column" gap={8}>
-					<Skeleton key={i} className={style.skeletonImage} />
+					<Skeleton key={i} className={`${style.skeletonImage} radius-1`} />
 					<div>
-						<Skeleton className={`${style.skeletonText} ${style["-small"]}`} />
-						<Skeleton className={style.skeletonText} />
+						<Skeleton
+							className={`${style.skeletonText} ${style["-small"]} radius-1`}
+						/>
+						<Skeleton className={`${style.skeletonText} radius-1`} />
 					</div>
 				</GapWrapper>
 			))}

--- a/src/app/_components/server/Jacket/Artist/loading.module.scss
+++ b/src/app/_components/server/Jacket/Artist/loading.module.scss
@@ -1,7 +1,6 @@
 @use "../../../../../styles/utils/mixins" as *;
 
 .skeletonImage {
-  border-radius: var(--radius-4);
 
   @include mq(sm) {
 	width: 100px;
@@ -17,7 +16,6 @@
 .skeletonText {
   height: 14px;
   margin: 4px 0;
-  border-radius: var(--radius-4);
 
   @include mq(sm) {
 	width: 100px;

--- a/src/app/_components/server/Jacket/NewRelease/Loading.tsx
+++ b/src/app/_components/server/Jacket/NewRelease/Loading.tsx
@@ -8,10 +8,12 @@ export const Loading = () => {
 		<>
 			{[...Array(12).keys()].map((i) => (
 				<GapWrapper key={i} direction="column" gap={8}>
-					<Skeleton key={i} className={style.skeletonImage} />
+					<Skeleton key={i} className={`${style.skeletonImage} radius-1`} />
 					<div>
-						<Skeleton className={`${style.skeletonText} ${style["-small"]}`} />
-						<Skeleton className={style.skeletonText} />
+						<Skeleton
+							className={`${style.skeletonText} ${style["-small"]} radius-1`}
+						/>
+						<Skeleton className={`${style.skeletonText} radius-1`} />
 					</div>
 				</GapWrapper>
 			))}

--- a/src/app/_components/server/Jacket/NewRelease/loading.module.scss
+++ b/src/app/_components/server/Jacket/NewRelease/loading.module.scss
@@ -1,7 +1,6 @@
 @use "../../../../../styles/utils/mixins" as *;
 
 .skeletonImage {
-  border-radius: var(--radius-4);
 
   @include mq(sm) {
 	width: 100px;
@@ -17,7 +16,6 @@
 .skeletonText {
   height: 14px;
   margin: 4px 0;
-  border-radius: var(--radius-4);
 
   @include mq(sm) {
 	width: 100px;

--- a/src/app/_components/server/Jacket/Popularity/Loading.tsx
+++ b/src/app/_components/server/Jacket/Popularity/Loading.tsx
@@ -8,10 +8,12 @@ export const Loading = () => {
 		<>
 			{[...Array(12).keys()].map((i) => (
 				<GapWrapper key={i} direction="column" gap={8}>
-					<Skeleton key={i} className={style.skeletonImage} />
+					<Skeleton key={i} className={`${style.skeletonImage} radius-1`} />
 					<div>
-						<Skeleton className={`${style.skeletonText} ${style["-small"]}`} />
-						<Skeleton className={style.skeletonText} />
+						<Skeleton
+							className={`${style.skeletonText} ${style["-small"]} radius-1`}
+						/>
+						<Skeleton className={`${style.skeletonText} radius-1`} />
 					</div>
 				</GapWrapper>
 			))}

--- a/src/app/_components/server/Jacket/Popularity/loading.module.scss
+++ b/src/app/_components/server/Jacket/Popularity/loading.module.scss
@@ -1,7 +1,6 @@
 @use "../../../../../styles/utils/mixins" as *;
 
 .skeletonImage {
-  border-radius: var(--radius-4);
 
   @include mq(sm) {
 	width: 100px;
@@ -17,7 +16,6 @@
 .skeletonText {
   height: 14px;
   margin: 4px 0;
-  border-radius: var(--radius-4);
 
   @include mq(sm) {
 	width: 100px;

--- a/src/styles/utils/_helpers.scss
+++ b/src/styles/utils/_helpers.scss
@@ -27,6 +27,17 @@
   }
 }
 
+// 丸みのユーティリティ
+@for $i from 1 through $loopLength {
+  .radius-#{$i} {
+    border-radius: #{$i * $baseSize}px;
+  }
+}
+
+.radius-full {
+  border-radius: 50%;
+}
+
 // 3点リーダー
 @for $i from 1 through $ellipsisLineLength {
 	  .textEllipsis-#{$i} {


### PR DESCRIPTION
- #211
でコンポーネントローディング中にSkeletonを表示するように修正を行ったが、ビルドするとなぜかCSSModulesで記述したborder-radiusのみ効かなくなるため、タグ内のstyleにborder-radiusを記述するように修正。
その他、border-radius用のヘルパーを作成。