### PR TITLE
Jacketコンポーネントでは画像最適化しないように変更

### DIFF
--- a/src/app/_components/server/Jacket/Jacket.tsx
+++ b/src/app/_components/server/Jacket/Jacket.tsx
@@ -18,7 +18,7 @@ export const Jacket = ({ href, album, artist, ...props }: JacketProps) => {
 	return (
 		<GapWrapper gap={8} direction="column">
 			<Link href={href} className={style.jacket}>
-				<Image className={style.jacketImg} {...props} />
+				<Image className={style.jacketImg} {...props} unoptimized />
 			</Link>
 			<GapWrapper direction="column">
 				<LinkText


### PR DESCRIPTION
- #214
で画像が表示されない現象が解決できなかったのでテスト的にJacketコンポーネントのImageタグの`unoptimized`を有効にしてみる。

メールを確認したところ、画像の最適化のしすぎでVercelのリソースの条件に引っかかったようなのでこれで問題なさそう。

<img width="613" height="277" alt="image" src="https://github.com/user-attachments/assets/b2135af3-cba6-4f02-9f53-063082cd9458" />

参考記事：
https://zenn.dev/wed_engineering/articles/next-image-unoptimized