### PR TITLE
デプロイ時のAPIfetch状況調査のためログ追加

### DIFF
--- a/src/app/api/spotify/albums-popularity/route.ts
+++ b/src/app/api/spotify/albums-popularity/route.ts
@@ -16,6 +16,9 @@ export async function GET(request: Request) {
 	});
 	const data: SpotifyAlbumsResponse = await res;
 
+	// Vercelログ監視
+	console.log(`[Spotify Popularity Albums] offset: ${offset}, limit: ${limit}`);
+
 	try {
 		if (!data.albums || data.albums.items.length === 0) {
 			return createResponse(

--- a/src/app/api/spotify/new-release/route.ts
+++ b/src/app/api/spotify/new-release/route.ts
@@ -16,6 +16,9 @@ export async function GET(request: Request) {
 	});
 	const data: SpotifyAlbumsResponse = await res;
 
+	// Vercelログ監視
+	console.log(`[Spotify New Albums] offset: ${offset}, limit: ${limit}`);
+
 	try {
 		if (!data.albums || data.albums.items.length === 0) {
 			return createResponse(


### PR DESCRIPTION
デプロイするたびにSpotifyAPIが429エラーを吐くようになったのでデプロイ時調査のためログを追加。