### PR TITLE
429エラー解消のため、プリフェッチを一部オフにした

### DIFF
--- a/src/app/(static)/albums/[album_id]/_components/AlbumHeader.tsx
+++ b/src/app/(static)/albums/[album_id]/_components/AlbumHeader.tsx
@@ -26,7 +26,7 @@ export const AlbumHeader = ({ name, artists, release_date, image }: Props) => {
 					<GapWrapper direction="row">
 						{artists.map((artist, index) => (
 							<Fragment key={artist.id}>
-								<LinkText href={PATH.ARTISTS(artist.id)}>
+								<LinkText href={PATH.ARTISTS(artist.id)} prefetch={false}>
 									{artist.name}
 								</LinkText>
 								{index < artists.length - 1 && <BasicText>,</BasicText>}

--- a/src/app/_components/server/Artist/Artist.tsx
+++ b/src/app/_components/server/Artist/Artist.tsx
@@ -17,7 +17,7 @@ export const Artist = ({ href, artist, ...props }: ArtistProps) => {
 	return (
 		<GapWrapper gap={8} direction="column">
 			{href && (
-				<Link href={href} className={style.artist}>
+				<Link href={href} className={style.artist} prefetch={false}>
 					<Image className={style.artistImg} {...props} unoptimized />
 				</Link>
 			)}
@@ -25,7 +25,11 @@ export const Artist = ({ href, artist, ...props }: ArtistProps) => {
 			{!href && <Image className={style.artistImg} {...props} unoptimized />}
 
 			<GapWrapper direction="column">
-				<LinkText href={artist?.href || PATH[404]} className="textEllipsis-2">
+				<LinkText
+					href={artist?.href || PATH[404]}
+					className="textEllipsis-2"
+					prefetch={false}
+				>
 					{artist?.name}
 				</LinkText>
 			</GapWrapper>

--- a/src/app/_components/server/Jacket/Jacket.tsx
+++ b/src/app/_components/server/Jacket/Jacket.tsx
@@ -17,7 +17,7 @@ type JacketProps = ImageProps & {
 export const Jacket = ({ href, album, artist, ...props }: JacketProps) => {
 	return (
 		<GapWrapper gap={8} direction="column">
-			<Link href={href} className={style.jacket}>
+			<Link href={href} className={style.jacket} prefetch={false}>
 				<Image className={style.jacketImg} {...props} unoptimized />
 			</Link>
 			<GapWrapper direction="column">
@@ -25,10 +25,13 @@ export const Jacket = ({ href, album, artist, ...props }: JacketProps) => {
 					href={album?.href || PATH[404]}
 					className="textEllipsis-2"
 					color="var(--slate-12)"
+					prefetch={false}
 				>
 					{album?.name}
 				</LinkText>
-				<LinkText href={artist?.href || PATH[404]}>{artist?.name}</LinkText>
+				<LinkText href={artist?.href || PATH[404]} prefetch={false}>
+					{artist?.name}
+				</LinkText>
 			</GapWrapper>
 		</GapWrapper>
 	);


### PR DESCRIPTION
SpotifyAPIへの過剰なフェッチにより、429エラーが返ってくるようになったのでその解消PR。

アーティストやアルバムをArtistコンポーネントやJacketコンポーネントで表示していたが表示している数が多く、その中でLinkタグを使用していたためPrefetchが走ってしまい、APIがコールされまくったのが原因だと思われる。

下記はTOPページでアーティストコンポーネントをスクロールした際のログ。

<img width="896" height="746" alt="image" src="https://github.com/user-attachments/assets/65d87fb2-b1f9-48ed-9367-e285c5d20b08" />
