### PR TITLE
Jacketコンポーネントのリンク文字が折り返されないバグを修正

### DIFF
--- a/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/loading.module.scss
+++ b/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/loading.module.scss
@@ -18,7 +18,7 @@
 	background-color: var(--gray-3);
 	padding: 8px;
 	flex-shrink: 0;
-	height: 200px;
+	height: 140px;
 
 	@include mq(sm) {
 		width: 280px;

--- a/src/app/_components/server/Jacket/Jacket.tsx
+++ b/src/app/_components/server/Jacket/Jacket.tsx
@@ -20,7 +20,8 @@ export const Jacket = ({ href, album, artist, ...props }: JacketProps) => {
 			<Link href={href} className={style.jacket} prefetch={false}>
 				<Image className={style.jacketImg} {...props} unoptimized />
 			</Link>
-			<GapWrapper direction="column">
+
+			<GapWrapper direction="column" style={{ wordBreak: "break-word" }}>
 				<LinkText
 					href={album?.href || PATH[404]}
 					className="textEllipsis-2"
@@ -29,7 +30,11 @@ export const Jacket = ({ href, album, artist, ...props }: JacketProps) => {
 				>
 					{album?.name}
 				</LinkText>
-				<LinkText href={artist?.href || PATH[404]} prefetch={false}>
+				<LinkText
+					href={artist?.href || PATH[404]}
+					className="textEllipsis-2"
+					prefetch={false}
+				>
 					{artist?.name}
 				</LinkText>
 			</GapWrapper>


### PR DESCRIPTION
## issue
- #226

## before:

<img width="550" height="261" alt="image" src="https://github.com/user-attachments/assets/950c906d-525b-42b8-9079-411df22c969c" />


## after:

<img width="603" height="278" alt="image" src="https://github.com/user-attachments/assets/52942ec2-ef45-4ee0-a6e3-d16680f6d5df" />
