### PR TITLE
アーティストの全アルバム表示用ページ作成

### DIFF
--- a/src/app/(static)/albums/[album_id]/page.tsx
+++ b/src/app/(static)/albums/[album_id]/page.tsx
@@ -3,11 +3,13 @@ import { Container as ArtistAlbumContainer } from "@/app/_components/server/Jack
 import { Loading as ArtistAlbumLoading } from "@/app/_components/server/Jacket/Artist/Loading";
 import { getAlbum } from "@/app/_fetchers/getAlbum";
 import { Section, Slider } from "@/app/_styles/components/blocks";
+import { LinkText } from "@/app/_styles/components/texts";
 import { PageWrapper } from "@/app/_styles/components/wrappers";
 import { Container as AlbumHeaderContainer } from "@/app/(static)/albums/[album_id]/_components/AlbumHeader/Container";
 import { Loading as AlbumHeaderLoading } from "@/app/(static)/albums/[album_id]/_components/AlbumHeader/Loading";
 import { Container as TrackListContainer } from "@/app/(static)/albums/[album_id]/_components/AlbumTrackList/Container";
 import { Loading as TrackListLoading } from "@/app/(static)/albums/[album_id]/_components/AlbumTrackList/Loading";
+import { PATH } from "@/utils/constants/path";
 
 type Props = {
 	params: Promise<{ album_id: string }>;
@@ -31,14 +33,21 @@ export default async function Album({ params }: Props) {
 				</Suspense>
 			</Section>
 
-			<Section>
-				<h2>アーティストのその他のアルバム</h2>
-				<Slider>
-					<Suspense fallback={<ArtistAlbumLoading />}>
-						<ArtistAlbumContainer artist_id={data.artists[0].id} />
-					</Suspense>
-				</Slider>
-			</Section>
+			<div>
+				<Section>
+					<h2>アーティストのその他のアルバム</h2>
+
+					<Slider>
+						<Suspense fallback={<ArtistAlbumLoading />}>
+							<ArtistAlbumContainer artist_id={data.artists[0].id} />
+						</Suspense>
+					</Slider>
+
+					<LinkText href={PATH.ARTIST_ALBUM(data.artists[0].id)}>
+						▶︎ ReadMoreAlbums...
+					</LinkText>
+				</Section>
+			</div>
 		</PageWrapper>
 	);
 }

--- a/src/app/(static)/artists/[artist_id]/albums/_components/Albums/Container.tsx
+++ b/src/app/(static)/artists/[artist_id]/albums/_components/Albums/Container.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import useSWRInfinite from "swr/infinite";
+import type { SpotifyArtistAlbumsResponse } from "@/app/_fetchers/types";
+import { Presentational } from "@/app/(static)/artists/[artist_id]/albums/_components/Albums/Presentational";
+import type { CustomResponse } from "@/app/api/type";
+
+type Props = {
+	artist_id: string;
+};
+
+export const Container = (props: Props) => {
+	const { artist_id } = props;
+
+	const [hasMore, setHasMore] = useState(true);
+	const lastElementRef = useRef<HTMLDivElement>(null);
+
+	const fetcher = async (url: string) => {
+		const fetcher = await fetch(url);
+		const res: CustomResponse<SpotifyArtistAlbumsResponse> =
+			await fetcher.json();
+
+		if (res.status.code !== 200) {
+			setHasMore(false);
+			return;
+		}
+
+		return res.data?.items;
+	};
+
+	const getKey = (page: number) => {
+		return `/api/spotify/artist-albums?artist_id=${artist_id}&offset=${page * 24}&limit=24`;
+	};
+
+	const { data, size, setSize, isValidating } = useSWRInfinite(getKey, fetcher);
+
+	useEffect(() => {
+		const observer = new IntersectionObserver(([entries]) => {
+			if (entries.isIntersecting && !isValidating && hasMore) {
+				setSize(size + 1);
+			}
+		});
+
+		if (lastElementRef.current) {
+			observer.observe(lastElementRef.current);
+		}
+		return () => {
+			if (lastElementRef.current) {
+				observer.unobserve(lastElementRef.current);
+			}
+		};
+	}, [isValidating, setSize, hasMore, size]);
+
+	return (
+		<Presentational
+			albums={data}
+			isValidation={isValidating}
+			lastElementRef={lastElementRef}
+		/>
+	);
+};

--- a/src/app/(static)/artists/[artist_id]/albums/_components/Albums/Loading.tsx
+++ b/src/app/(static)/artists/[artist_id]/albums/_components/Albums/Loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@radix-ui/themes";
+
+export const Loading = () => {
+	return (
+		<>
+			{[...Array(24).keys()].map((i) => (
+				<Skeleton
+					key={i}
+					loading
+					style={{
+						borderRadius: "var(--radius-4)",
+						aspectRatio: "1 / 1",
+					}}
+				>
+					<div>
+						<br />
+					</div>
+				</Skeleton>
+			))}
+		</>
+	);
+};

--- a/src/app/(static)/artists/[artist_id]/albums/_components/Albums/Presentational.tsx
+++ b/src/app/(static)/artists/[artist_id]/albums/_components/Albums/Presentational.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Jacket } from "@/app/_components/server/Jacket/Jacket";
+import type { SpotifyAlbumItem } from "@/app/_fetchers/types";
+import { InfiniteGrid } from "@/app/_styles/components/blocks";
+import { Loading } from "@/app/(static)/artists/[artist_id]/albums/_components/Albums/Loading";
+import { PATH } from "@/utils/constants/path";
+
+type Props = {
+	albums: (SpotifyAlbumItem[] | undefined)[] | undefined;
+	isValidation: boolean;
+	lastElementRef: React.RefObject<HTMLDivElement | null>;
+};
+
+export const Presentational = (props: Props) => {
+	const { albums, isValidation, lastElementRef } = props;
+
+	return (
+		<>
+			<InfiniteGrid>
+				{albums?.map((items) => (
+					<React.Fragment key={items ? `parent-${items[0].id}` : "no-items"}>
+						{items?.map((item) => (
+							<Jacket
+								key={item.id}
+								href={PATH.ALBUMS(item.id)}
+								fill
+								priority
+								src={item.images[0].url}
+								album={{ name: item.name, href: PATH.ALBUMS(item.id) }}
+								alt="最新リリースアルバム画像"
+							/>
+						))}
+					</React.Fragment>
+				))}
+
+				{isValidation && <Loading />}
+			</InfiniteGrid>
+
+			<div ref={lastElementRef} />
+		</>
+	);
+};

--- a/src/app/(static)/artists/[artist_id]/albums/_components/ArtistAlbumTitle/Container.tsx
+++ b/src/app/(static)/artists/[artist_id]/albums/_components/ArtistAlbumTitle/Container.tsx
@@ -1,0 +1,12 @@
+import { getArtist } from "@/app/_fetchers/getArtist";
+import { Presentational } from "@/app/(static)/artists/[artist_id]/albums/_components/ArtistAlbumTitle/Presentational";
+
+type Props = {
+	artist_id: string;
+};
+
+export const Container = async ({ artist_id }: Props) => {
+	const artistData = await getArtist(artist_id);
+
+	return <Presentational artistData={artistData} />;
+};

--- a/src/app/(static)/artists/[artist_id]/albums/_components/ArtistAlbumTitle/Presentational.tsx
+++ b/src/app/(static)/artists/[artist_id]/albums/_components/ArtistAlbumTitle/Presentational.tsx
@@ -1,0 +1,15 @@
+import type { SpotifyArtistResponse } from "@/app/_fetchers/types";
+
+type Props = {
+	artistData: SpotifyArtistResponse;
+};
+
+export const Presentational = (props: Props) => {
+	const { artistData } = props;
+
+	return (
+		<div>
+			<h2>{artistData.name} の全てのアルバム</h2>
+		</div>
+	);
+};

--- a/src/app/(static)/artists/[artist_id]/albums/page.tsx
+++ b/src/app/(static)/artists/[artist_id]/albums/page.tsx
@@ -1,0 +1,22 @@
+import { Section } from "@/app/_styles/components/blocks";
+import { PageWrapper } from "@/app/_styles/components/wrappers";
+import { Container } from "@/app/(static)/artists/[artist_id]/albums/_components/Albums/Container";
+import { Container as TitleContainer } from "@/app/(static)/artists/[artist_id]/albums/_components/ArtistAlbumTitle/Container";
+
+type Props = {
+	params: Promise<{ artist_id: string }>;
+};
+
+export default async function ArtistAlbumsPage({ params }: Props) {
+	const { artist_id } = await params;
+
+	return (
+		<PageWrapper>
+			<Section>
+				<TitleContainer artist_id={artist_id} />
+
+				<Container artist_id={artist_id} />
+			</Section>
+		</PageWrapper>
+	);
+}

--- a/src/app/(static)/artists/[artist_id]/page.tsx
+++ b/src/app/(static)/artists/[artist_id]/page.tsx
@@ -6,13 +6,13 @@ import { Container as ArtistAlbumContainer } from "@/app/_components/server/Jack
 import { Loading as ArtistAlbumLoading } from "@/app/_components/server/Jacket/Artist/Loading";
 
 import { Section, Slider } from "@/app/_styles/components/blocks";
+import { LinkText } from "@/app/_styles/components/texts";
 import { PageWrapper } from "@/app/_styles/components/wrappers";
-
 import { Container as ArtistHeaderContainer } from "@/app/(static)/artists/[artist_id]/_components/ArtistHeader/Container";
 import { Loading as ArtistHeaderLoading } from "@/app/(static)/artists/[artist_id]/_components/ArtistHeader/Loading";
-
 import { Container as TopTracksContainer } from "@/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/Container";
 import { Loading } from "@/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/Loading";
+import { PATH } from "@/utils/constants/path";
 
 type Props = {
 	params: Promise<{ artist_id: string }>;
@@ -36,14 +36,21 @@ export default async function ArtistPage({ params }: Props) {
 				</Suspense>
 			</Section>
 
-			<Section>
-				<h2>アルバム</h2>
-				<Slider>
-					<Suspense fallback={<ArtistAlbumLoading />}>
-						<ArtistAlbumContainer artist_id={artist_id} />
-					</Suspense>
-				</Slider>
-			</Section>
+			<div>
+				<Section>
+					<h2>アルバム</h2>
+
+					<Slider>
+						<Suspense fallback={<ArtistAlbumLoading />}>
+							<ArtistAlbumContainer artist_id={artist_id} />
+						</Suspense>
+					</Slider>
+
+					<LinkText href={PATH.ARTIST_ALBUM(artist_id)}>
+						▶︎ ReadMoreAlbums...
+					</LinkText>
+				</Section>
+			</div>
 		</PageWrapper>
 	);
 }

--- a/src/app/(static)/new/_components/InfiniteNewAlbums/Presentational.tsx
+++ b/src/app/(static)/new/_components/InfiniteNewAlbums/Presentational.tsx
@@ -38,13 +38,9 @@ export const Presentational = (props: Props) => {
 						))}
 					</React.Fragment>
 				))}
-			</InfiniteGrid>
 
-			{isValidation && (
-				<InfiniteGrid>
-					<Loading />
-				</InfiniteGrid>
-			)}
+				{isValidation && <Loading />}
+			</InfiniteGrid>
 
 			<div ref={lastElementRef} />
 		</>

--- a/src/app/(static)/popularity/_components/InfinitePopularityAlbums/Presentational.tsx
+++ b/src/app/(static)/popularity/_components/InfinitePopularityAlbums/Presentational.tsx
@@ -38,13 +38,9 @@ export const Presentational = (props: Props) => {
 						))}
 					</React.Fragment>
 				))}
-			</InfiniteGrid>
 
-			{isValidation && (
-				<InfiniteGrid>
-					<Loading />
-				</InfiniteGrid>
-			)}
+				{isValidation && <Loading />}
+			</InfiniteGrid>
 
 			<div ref={lastElementRef} />
 		</>

--- a/src/app/_components/server/Jacket/Artist/Container.tsx
+++ b/src/app/_components/server/Jacket/Artist/Container.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export const Container = async (props: Props) => {
 	const { artist_id } = props;
-	const artistAlbums = await getAlbumsByArtist(artist_id);
+	const artistAlbums = await getAlbumsByArtist({ artist_id });
 
 	return <Presentational artistAlbums={artistAlbums} />;
 };

--- a/src/app/_fetchers/getAlbumsByArtist.ts
+++ b/src/app/_fetchers/getAlbumsByArtist.ts
@@ -5,9 +5,17 @@ import { fetchSpotifyData } from "@/libs/spotify";
  * Spotify のアーティストのアルバム情報を取得
  * @returns {Promise<SpotifyArtistAlbumsResponse>}
  */
-export async function getAlbumsByArtist(artist_id: string) {
+export async function getAlbumsByArtist({
+	artist_id,
+	offset = 0,
+	limit = 20,
+}: {
+	artist_id: string;
+	offset?: number;
+	limit?: number;
+}) {
 	const res = await fetchSpotifyData<SpotifyArtistAlbumsResponse>(
-		`artists/${artist_id}/albums`,
+		`artists/${artist_id}/albums?offset=${offset}&limit=${limit}`,
 	);
 	return res;
 }

--- a/src/app/api/spotify/artist-albums/route.ts
+++ b/src/app/api/spotify/artist-albums/route.ts
@@ -1,0 +1,60 @@
+import { getAlbumsByArtist } from "@/app/_fetchers/getAlbumsByArtist";
+import { createResponse } from "@/libs/next/response";
+
+export async function GET(request: Request) {
+	const { searchParams } = new URL(request.url);
+	const artist_id = searchParams.get("artist_id");
+	const offset = Number(searchParams.get("offset") || 0);
+	const limit = Number(searchParams.get("limit") || 24);
+
+	if (!artist_id) {
+		return createResponse(
+			{
+				status: {
+					code: 400,
+					message: "アーティストが指定されていません",
+				},
+			},
+			{ status: 400 },
+		);
+	}
+
+	const res = await getAlbumsByArtist({ artist_id: artist_id, offset, limit });
+	const data = await res;
+
+	try {
+		if (!data.items || data.items.length === 0) {
+			return createResponse(
+				{
+					status: {
+						code: 404,
+						message: "アーティストのアルバム情報が見つかりませんでした",
+					},
+				},
+				{ status: 404 },
+			);
+		}
+
+		return createResponse(
+			{
+				data: data,
+				status: {
+					code: 200,
+					message: "アーティストのアルバム情報取得に成功しました",
+				},
+			},
+			{ status: 200 },
+		);
+	} catch (_error) {
+		console.error("Error fetching artist albums", _error);
+		return createResponse(
+			{
+				status: {
+					code: 500,
+					message: "アーティストのアルバム情報取得に失敗しました",
+				},
+			},
+			{ status: 500 },
+		);
+	}
+}

--- a/src/utils/constants/path.ts
+++ b/src/utils/constants/path.ts
@@ -9,6 +9,7 @@ export const PATH = {
 
 	ALBUMS: (album_id: string) => `/albums/${album_id}`,
 	ARTISTS: (artist_id: string) => `/artists/${artist_id}`,
+	ARTIST_ALBUM: (artist_id: string) => `/artists/${artist_id}/albums`,
 
 	404: "/404",
 } as const;


### PR DESCRIPTION
- アーティストのアルバム取得APIにoffset,limitの指定ができるように変更
- アーティストのアルバム全件表示（無限スクロール）ページ作成
- アーティストページ・アルバムページに導線追加


https://github.com/user-attachments/assets/96064837-1eb6-4b3b-a0c8-ae33d9c5c4bc

