### PR TITLE
アーティストページの参照落ち解消

### DIFF
--- a/src/app/(static)/artists/[artist_id]/_components/ArtistHeader/Presentational.tsx
+++ b/src/app/(static)/artists/[artist_id]/_components/ArtistHeader/Presentational.tsx
@@ -15,7 +15,11 @@ export const Presentational = (props: Props) => {
 				<Artist
 					fill
 					priority
-					src={artistData.images[0].url}
+					src={
+						artistData.images.length > 0
+							? artistData.images[0].url
+							: "/images/no-image.png"
+					}
 					alt={`${artistData.name}の画像`}
 					style={{ boxShadow: "var(--slate-2) 0 10px 25px" }}
 				/>

--- a/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/Presentational.tsx
+++ b/src/app/(static)/artists/[artist_id]/_components/Track/TopTrackList/Presentational.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { BasicText } from "@/app/_styles/components/texts";
 import { Container } from "@/app/(static)/artists/[artist_id]/_components/Track/Container";
-
 import style from "./index.module.scss";
 
 type Props = {
@@ -13,16 +13,24 @@ export const Presentational = (props: Props) => {
 	const { tracks, trackGroups } = props;
 
 	return (
-		<div className={style.scrollWrapper}>
-			<div className={style.gridContainer}>
-				{trackGroups.map((group) => (
-					<div key={group[0].id} className={style.column}>
-						{group.map((track) => (
-							<Container key={track.id} tracks={tracks} track={track} />
+		<>
+			{tracks.length === 0 && (
+				<BasicText size={16}>曲が見つかりませんでした。</BasicText>
+			)}
+
+			{tracks.length > 0 && (
+				<div className={style.scrollWrapper}>
+					<div className={style.gridContainer}>
+						{trackGroups.map((group) => (
+							<div key={group[0].id} className={style.column}>
+								{group.map((track) => (
+									<Container key={track.id} tracks={tracks} track={track} />
+								))}
+							</div>
 						))}
 					</div>
-				))}
-			</div>
-		</div>
+				</div>
+			)}
+		</>
 	);
 };


### PR DESCRIPTION
- #228
上記Issueの解消

- アーティストページの人気曲が１件も返却されなかった場合に０件テキストを表示するように修正